### PR TITLE
Fix settings menu controls not appearing

### DIFF
--- a/ui/HUD.tscn
+++ b/ui/HUD.tscn
@@ -74,6 +74,3 @@ layout_mode = 1
 
 [node name="SettingsPanel" parent="Root/Panels" instance=ExtResource("10_r5s0p")]
 layout_mode = 1
-
-[node name="SettingsPanel" parent="Root/Panels/SettingsPanel" instance=ExtResource("10_r5s0p")]
-layout_mode = 1


### PR DESCRIPTION
## Summary
- remove the redundant nested SettingsPanel instance in the HUD so the real settings controls are visible when the tab opens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6d12d33dc8326834bbdeba54dfe74