### PR TITLE
Adjust SettingsPanel layout mode

### DIFF
--- a/scenes/ui/SettingsPanel.tscn
+++ b/scenes/ui/SettingsPanel.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Texture2D" uid="uid://71eprqhthme4" path="res://art/ui/settings_menu.png" id="2_cjf3c"]
 
 [node name="SettingsPanel" type="Control"]
-layout_mode = 3
+layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0

--- a/ui/HUD.tscn
+++ b/ui/HUD.tscn
@@ -73,7 +73,3 @@ layout_mode = 1
 layout_mode = 1
 
 [node name="SettingsPanel" parent="Root/Panels" instance=ExtResource("10_r5s0p")]
-layout_mode = 1
-
-[node name="SettingsPanel" parent="Root/Panels/SettingsPanel" instance=ExtResource("10_r5s0p")]
-layout_mode = 1


### PR DESCRIPTION
## Summary
- set the SettingsPanel root control to use anchored layout so it fills its HUD container and shows its contents

## Testing
- `godot4 --headless --run-tests` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d12d33dc8326834bbdeba54dfe74